### PR TITLE
아이디어 제공자 정보 넣기

### DIFF
--- a/index.html
+++ b/index.html
@@ -450,6 +450,12 @@ label {
             <br />
             (c) 2018-2020 k. hibiya, hibiya inemuri
             <br />
+            <br />
+						아이디어 제공: <a style="color: inherit" href="https://codepen.io/mu-hun/full/YvEVjv">미안합니다 — CodePen</a>
+            <br />
+						<a style="color: inherit" href="https://muhun.kim">muhun.kim</a>
+            <br />
+            <br />
             all rights reserved
             <br />
             AND no responsibility reserved


### PR DESCRIPTION
오랜 시간이 지나서 기여를 증명하러(?) 왔습니다.

2018년 당시 종이님이 제 트윗을 통해 아마 보셨던 해당 [codepen 링크](https://codepen.io/mu-hun/full/YvEVjv)와 제 이름을 가리기는 도메인을 카피라이트 부분에 추가했습니다.

수락해 주시면 좋겠습니다. 🥺

<img src="https://github.com/user-attachments/assets/9c3ddebc-acdd-44f0-b8ed-13d0b56b9fa3" width="300em"/>